### PR TITLE
Remove deprecated -p option from webpack command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest",
     "watch": "webpack --watch --mode=development",
     "build:dev": "webpack --mode=development",
-    "build": "webpack -p --mode=production",
+    "build": "webpack --mode=production",
     "lint": "standard",
     "lint:fix": "standard --fix"
   },


### PR DESCRIPTION
This has been replaced with `--mode production (see [this GitHub issue](https://github.com/webpack/webpack-cli/issues/1934)). Since `-p` now raises an unknown option warning, this was causing build failures.