### PR TITLE
Get tests passing again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         node-version: 12.x
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
     - name: Install dependencies
       run: script/bootstrap
     - name: Run tests


### PR DESCRIPTION
The `actions/setup-ruby@v1` action in the test workflow was using a default Ruby version of `>= 2.4`, rather than the expected behaviour of relying on `.ruby-version`. This resolved to version 3.0.0, which involves multiple breaking changes.

Swapping the action to use `ruby/setup-ruby` action _does_ take the version from `.ruby-version`, solving this problem.