### PR TITLE
Update the tag for our forked zendesk_apps_tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem "foreman", "~> 0.87"
 
 # Forked from "zendesk/zendesk_apps_tools" to fix security alerts
-gem "zendesk_apps_tools", github: "dxw/zendesk_apps_tools", tag: "v3.8.1-dxw2"
+gem "zendesk_apps_tools", github: "dxw/zendesk_apps_tools", tag: "v3.8.1-dxw3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/dxw/zendesk_apps_tools
-  revision: b5af38abc0a69e781fd473452a4a97728b6ee005
-  tag: v3.8.1-dxw2
+  revision: 0e8ea5231f3380e691da04f95e850e24860db4c7
+  tag: v3.8.1-dxw3
   specs:
     zendesk_apps_tools (3.8.1)
+      dxw-zendesk_apps_support (~> 4.29.5)
       execjs (~> 2.7.0)
       faraday (~> 0.9.2)
       faye-websocket (~> 0.11.0)
@@ -14,16 +15,27 @@ GIT
       sinatra-cross_origin (~> 0.3.1)
       thin (~> 1.7.2)
       thor (~> 0.19.4)
-      zendesk_apps_support (~> 4.29.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     crass (1.0.6)
     daemons (1.3.1)
+    dxw-zendesk_apps_support (4.29.5)
+      erubis
+      i18n
+      image_size (~> 2.0.2)
+      ipaddress_2 (~> 0.13.0)
+      json
+      loofah (>= 2.2.3, < 2.10.0)
+      mimemagic (~> 0.3.3)
+      nokogiri (>= 1.8.5, < 1.12.0)
+      rb-inotify (= 0.9.10)
+      sass
+      sassc
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
@@ -32,28 +44,30 @@ GEM
     faye-websocket (0.11.0)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.9.25)
+    ffi (1.14.2)
     foreman (0.87.2)
     hitimes (2.0.0)
-    i18n (1.8.5)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
-    json (2.3.1)
+    json (2.5.1)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    loofah (2.2.3)
+    loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mimemagic (0.3.5)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    racc (1.5.2)
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
@@ -62,17 +76,15 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (1.11.4)
-      bundler
-      ffi (~> 1.9.6)
-      sass (>= 3.3.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -90,18 +102,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zendesk_apps_support (4.29.5)
-      erubis
-      i18n
-      image_size (~> 2.0.2)
-      ipaddress_2 (~> 0.13.0)
-      json
-      loofah (~> 2.2.3)
-      mimemagic (~> 0.3.3)
-      nokogiri (>= 1.8.5, < 1.11.0)
-      rb-inotify (= 0.9.10)
-      sass
-      sassc (~> 1.11.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
There have been a couple of underlying security updates, we've reported the issue upstream. However as mentioned previously, activity is quite low.