### PR TITLE
Correctly handle cases where a project has no account manager

### DIFF
--- a/src/javascripts/lib/project.js
+++ b/src/javascripts/lib/project.js
@@ -88,7 +88,9 @@ class Project {
       this._fields['Account Manager']
     )
 
-    return accountManager[0].fields.Name
+    if (accountManager.length > 0) {
+      return accountManager[0].fields.Name
+    }
   }
 
   async _gitRepositories () {


### PR DESCRIPTION
Previously we were attempting to query a related object for a project's account manager, even when there was no such person.

This commit adds a guard which checks for the existence of a relationship before attempting to query it.