### PR TITLE
Update mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_portile2 (2.5.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)


### PR DESCRIPTION
Versions 0.3.5 and earlier have been yanked from the rubygems repository; this updates mimemagic to 0.3.6.