### PR TITLE
Use the official zendesk apps tools gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,4 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem "foreman", "~> 0.87"
-
-# Forked from "zendesk/zendesk_apps_tools" to fix security alerts
-gem "zendesk_apps_tools", github: "dxw/zendesk_apps_tools", tag: "v3.8.1-dxw3"
+gem "zendesk_apps_tools"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,53 +1,23 @@
-GIT
-  remote: https://github.com/dxw/zendesk_apps_tools
-  revision: 0e8ea5231f3380e691da04f95e850e24860db4c7
-  tag: v3.8.1-dxw3
-  specs:
-    zendesk_apps_tools (3.8.1)
-      dxw-zendesk_apps_support (~> 4.29.5)
-      execjs (~> 2.7.0)
-      faraday (~> 0.9.2)
-      faye-websocket (~> 0.11.0)
-      listen (~> 2.10)
-      rack-livereload
-      rubyzip (~> 1.3.0)
-      sinatra (~> 2.1.0)
-      sinatra-cross_origin (~> 0.3.1)
-      thin (~> 1.7.2)
-      thor (~> 0.19.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crass (1.0.6)
-    daemons (1.3.1)
-    dxw-zendesk_apps_support (4.29.5)
-      erubis
-      i18n
-      image_size (~> 2.0.2)
-      ipaddress_2 (~> 0.13.0)
-      json
-      loofah (>= 2.2.3, < 2.10.0)
-      mimemagic (~> 0.3.3)
-      nokogiri (>= 1.8.5, < 1.12.0)
-      rb-inotify (= 0.9.10)
-      sass
-      sassc
+    daemons (1.4.1)
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faye-websocket (0.11.0)
+    faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
-    ffi (1.14.2)
+    ffi (1.15.4)
     foreman (0.87.2)
     hitimes (2.0.0)
-    i18n (1.8.8)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_size (2.0.2)
     ipaddress_2 (0.13.0)
@@ -56,31 +26,25 @@ GEM
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    loofah (2.9.0)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
-    mini_portile2 (2.5.1)
+    marcel (1.0.2)
+    mini_portile2 (2.6.1)
     multipart-post (2.1.1)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
-    nokogiri (1.11.4)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     racc (1.5.2)
-    rack (2.2.3)
+    rack (1.6.13)
     rack-livereload (0.3.17)
       rack
-    rack-protection (2.1.0)
+    rack-protection (1.5.5)
       rack
-    rake (13.0.3)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.0)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    ruby2_keywords (0.0.4)
-    rubyzip (1.3.0)
+    rubyzip (1.2.4)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -88,13 +52,12 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.1.0)
-      tilt (~> 2.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sinatra-cross_origin (0.3.2)
-    thin (1.7.2)
+    thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
@@ -102,16 +65,40 @@ GEM
     tilt (2.0.10)
     timers (4.0.4)
       hitimes
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    zendesk_apps_support (4.29.10)
+      erubis
+      i18n
+      image_size (~> 2.0.2)
+      ipaddress_2 (~> 0.13.0)
+      json
+      loofah (~> 2.3.1)
+      marcel
+      nokogiri
+      rb-inotify (= 0.9.10)
+      sass
+      sassc
+    zendesk_apps_tools (3.8.5)
+      execjs (~> 2.7.0)
+      faraday (~> 0.9.2)
+      faye-websocket (~> 0.10.7)
+      listen (~> 2.10)
+      rack-livereload
+      rubyzip (~> 1.2.1)
+      sinatra (~> 1.4.6)
+      sinatra-cross_origin (~> 0.3.1)
+      thin (~> 1.8.0)
+      thor (~> 0.19.4)
+      zendesk_apps_support (~> 4.29.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   foreman (~> 0.87)
-  zendesk_apps_tools!
+  zendesk_apps_tools
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
The dependencies have been updated, so we want to use the official gem again and resolve the security alerts.