### PR TITLE
Replace precss with precss-v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "postcss-import": "^14.1.0",
         "postcss-loader": "^7.0.0",
         "postcss-preset-env": "^7.6.0",
-        "precss": "^4.0.0",
+        "precss-v8": "^5.0.1",
         "standard": "^17.0.0",
         "webpack": "^5.72.1",
         "webpack-cli": "^4.9.2"
@@ -11249,12 +11249,12 @@
       }
     },
     "node_modules/postcss-nested": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.1.tgz",
-      "integrity": "sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
+      "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.21",
+        "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2"
       }
     },
@@ -11610,25 +11610,28 @@
         "node": ">=6.14.4"
       }
     },
-    "node_modules/precss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/precss/-/precss-4.0.0.tgz",
-      "integrity": "sha512-cRPZMKpHLZXR6gJlrXRjJe7SQMf+wYxg6rKp+TwYsYABjApSj9z8E8yIlagqADaWyikeIZttaNU6xqSjFIAP/g==",
+    "node_modules/precss-v8": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/precss-v8/-/precss-v8-5.0.1.tgz",
+      "integrity": "sha512-G+IEjD7e7IBDcbM1waLPXfuS1ShnE6JDay8mum8EVX91uTwJhml6IKcCH0KbIAG59RN4JOO3DG5MPVjcYVcQeA==",
       "dev": true,
       "dependencies": {
-        "postcss": "^7.0.6",
-        "postcss-advanced-variables": "^3.0.0",
+        "postcss": "^8.3.11",
+        "postcss-advanced-variables": "^3.0.1",
         "postcss-atroot": "^0.1.3",
         "postcss-extend-rule": "^2.0.0",
-        "postcss-nested": "^4.1.0",
-        "postcss-preset-env": "^6.4.0",
+        "postcss-nested": "^4.2.3",
+        "postcss-preset-env": "^6.7.0",
         "postcss-property-lookup": "^2.0.0"
       },
       "engines": {
         "node": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.11"
       }
     },
-    "node_modules/precss/node_modules/autoprefixer": {
+    "node_modules/precss-v8/node_modules/autoprefixer": {
       "version": "9.8.8",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.8.tgz",
       "integrity": "sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==",
@@ -11650,33 +11653,24 @@
         "url": "https://tidelift.com/funding/github/npm/autoprefixer"
       }
     },
-    "node_modules/precss/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+    "node_modules/precss-v8/node_modules/autoprefixer/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/precss/node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
+        "node": ">=6.0.0"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
-    "node_modules/precss/node_modules/css-blank-pseudo": {
+    "node_modules/precss-v8/node_modules/css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
       "integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
@@ -11691,7 +11685,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/css-has-pseudo": {
+    "node_modules/precss-v8/node_modules/css-blank-pseudo/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/css-has-pseudo": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
       "integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
@@ -11707,7 +11718,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
+    "node_modules/precss-v8/node_modules/css-has-pseudo/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
       "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
@@ -11721,7 +11749,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/precss/node_modules/css-prefers-color-scheme": {
+    "node_modules/precss-v8/node_modules/css-prefers-color-scheme": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
       "integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
@@ -11736,13 +11764,30 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/cssdb": {
+    "node_modules/precss-v8/node_modules/css-prefers-color-scheme/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
       "integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==",
       "dev": true
     },
-    "node_modules/precss/node_modules/cssesc": {
+    "node_modules/precss-v8/node_modules/cssesc": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
       "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
@@ -11754,31 +11799,13 @@
         "node": ">=4"
       }
     },
-    "node_modules/precss/node_modules/picocolors": {
+    "node_modules/precss-v8/node_modules/picocolors": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
       "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
       "dev": true
     },
-    "node_modules/precss/node_modules/postcss": {
-      "version": "7.0.36",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-      "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/precss/node_modules/postcss-attribute-case-insensitive": {
+    "node_modules/precss-v8/node_modules/postcss-attribute-case-insensitive": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz",
       "integrity": "sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==",
@@ -11788,7 +11815,24 @@
         "postcss-selector-parser": "^6.0.2"
       }
     },
-    "node_modules/precss/node_modules/postcss-color-functional-notation": {
+    "node_modules/precss-v8/node_modules/postcss-attribute-case-insensitive/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-color-functional-notation": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
       "integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
@@ -11801,7 +11845,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-color-hex-alpha": {
+    "node_modules/precss-v8/node_modules/postcss-color-functional-notation/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-color-hex-alpha": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
       "integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
@@ -11814,7 +11875,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-color-rebeccapurple": {
+    "node_modules/precss-v8/node_modules/postcss-color-hex-alpha/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-color-rebeccapurple": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
       "integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
@@ -11827,7 +11905,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-custom-media": {
+    "node_modules/precss-v8/node_modules/postcss-color-rebeccapurple/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-custom-media": {
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
       "integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
@@ -11839,7 +11934,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-custom-properties": {
+    "node_modules/precss-v8/node_modules/postcss-custom-media/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-custom-properties": {
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
       "integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
@@ -11852,7 +11964,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-custom-selectors": {
+    "node_modules/precss-v8/node_modules/postcss-custom-properties/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-custom-selectors": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
       "integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
@@ -11865,7 +11994,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
+    "node_modules/precss-v8/node_modules/postcss-custom-selectors/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
       "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
@@ -11879,7 +12025,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/precss/node_modules/postcss-dir-pseudo-class": {
+    "node_modules/precss-v8/node_modules/postcss-dir-pseudo-class": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
       "integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
@@ -11892,7 +12038,24 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
+    "node_modules/precss-v8/node_modules/postcss-dir-pseudo-class/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
       "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
@@ -11906,7 +12069,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/precss/node_modules/postcss-double-position-gradients": {
+    "node_modules/precss-v8/node_modules/postcss-double-position-gradients": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
       "integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
@@ -11919,7 +12082,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-env-function": {
+    "node_modules/precss-v8/node_modules/postcss-double-position-gradients/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-env-function": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
       "integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
@@ -11932,7 +12112,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-focus-visible": {
+    "node_modules/precss-v8/node_modules/postcss-env-function/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-focus-visible": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
       "integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
@@ -11944,7 +12141,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-focus-within": {
+    "node_modules/precss-v8/node_modules/postcss-focus-visible/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-focus-within": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
       "integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
@@ -11956,7 +12170,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-font-variant": {
+    "node_modules/precss-v8/node_modules/postcss-focus-within/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-font-variant": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.1.tgz",
       "integrity": "sha512-I3ADQSTNtLTTd8uxZhtSOrTCQ9G4qUVKPjHiDk0bV75QSxXjVWiJVJ2VLdspGUi9fbW9BcjKJoRvxAH1pckqmA==",
@@ -11965,7 +12196,24 @@
         "postcss": "^7.0.2"
       }
     },
-    "node_modules/precss/node_modules/postcss-gap-properties": {
+    "node_modules/precss-v8/node_modules/postcss-font-variant/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-gap-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
       "integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
@@ -11977,7 +12225,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-image-set-function": {
+    "node_modules/precss-v8/node_modules/postcss-gap-properties/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-image-set-function": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
       "integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
@@ -11990,7 +12255,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-initial": {
+    "node_modules/precss-v8/node_modules/postcss-image-set-function/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-initial": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.4.tgz",
       "integrity": "sha512-3RLn6DIpMsK1l5UUy9jxQvoDeUN4gP939tDcKUHD/kM8SGSKbFAnvkpFpj3Bhtz3HGk1jWY5ZNWX6mPta5M9fg==",
@@ -11999,7 +12281,24 @@
         "postcss": "^7.0.2"
       }
     },
-    "node_modules/precss/node_modules/postcss-lab-function": {
+    "node_modules/precss-v8/node_modules/postcss-initial/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-lab-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
       "integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
@@ -12013,7 +12312,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-logical": {
+    "node_modules/precss-v8/node_modules/postcss-lab-function/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-logical": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
       "integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
@@ -12025,7 +12341,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-media-minmax": {
+    "node_modules/precss-v8/node_modules/postcss-logical/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-media-minmax": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
       "integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
@@ -12037,7 +12370,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-nesting": {
+    "node_modules/precss-v8/node_modules/postcss-media-minmax/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-nesting": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
       "integrity": "sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==",
@@ -12049,7 +12399,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-overflow-shorthand": {
+    "node_modules/precss-v8/node_modules/postcss-nesting/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-overflow-shorthand": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
       "integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
@@ -12061,7 +12428,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-page-break": {
+    "node_modules/precss-v8/node_modules/postcss-overflow-shorthand/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-page-break": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
       "integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
@@ -12070,7 +12454,24 @@
         "postcss": "^7.0.2"
       }
     },
-    "node_modules/precss/node_modules/postcss-place": {
+    "node_modules/precss-v8/node_modules/postcss-page-break/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-place": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
       "integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
@@ -12083,7 +12484,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-preset-env": {
+    "node_modules/precss-v8/node_modules/postcss-place/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-preset-env": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.1.tgz",
       "integrity": "sha512-rlRkgX9t0v2On33n7TK8pnkcYOATGQSv48J2RS8GsXhqtg+xk6AummHP88Y5mJo0TLJelBjePvSjScTNkj3+qw==",
@@ -12131,7 +12549,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-pseudo-class-any-link": {
+    "node_modules/precss-v8/node_modules/postcss-preset-env/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-pseudo-class-any-link": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
       "integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
@@ -12144,7 +12579,24 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/precss/node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
+    "node_modules/precss-v8/node_modules/postcss-pseudo-class-any-link/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
       "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
@@ -12158,7 +12610,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/precss/node_modules/postcss-replace-overflow-wrap": {
+    "node_modules/precss-v8/node_modules/postcss-replace-overflow-wrap": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
       "integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
@@ -12167,7 +12619,24 @@
         "postcss": "^7.0.2"
       }
     },
-    "node_modules/precss/node_modules/postcss-selector-not": {
+    "node_modules/precss-v8/node_modules/postcss-replace-overflow-wrap/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/precss-v8/node_modules/postcss-selector-not": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.1.tgz",
       "integrity": "sha512-YolvBgInEK5/79C+bdFMyzqTg6pkYqDbzZIST/PDMqa/o3qtXenD05apBG2jLgT0/BQ77d4U2UK12jWpilqMAQ==",
@@ -12177,16 +12646,21 @@
         "postcss": "^7.0.2"
       }
     },
-    "node_modules/precss/node_modules/supports-color": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-      "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+    "node_modules/precss-v8/node_modules/postcss-selector-not/node_modules/postcss": {
+      "version": "7.0.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
       "dev": true,
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/prelude-ls": {
@@ -22280,12 +22754,12 @@
       }
     },
     "postcss-nested": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.1.tgz",
-      "integrity": "sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
+      "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.21",
+        "postcss": "^7.0.32",
         "postcss-selector-parser": "^6.0.2"
       },
       "dependencies": {
@@ -22554,18 +23028,18 @@
         "uniq": "^1.0.1"
       }
     },
-    "precss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/precss/-/precss-4.0.0.tgz",
-      "integrity": "sha512-cRPZMKpHLZXR6gJlrXRjJe7SQMf+wYxg6rKp+TwYsYABjApSj9z8E8yIlagqADaWyikeIZttaNU6xqSjFIAP/g==",
+    "precss-v8": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/precss-v8/-/precss-v8-5.0.1.tgz",
+      "integrity": "sha512-G+IEjD7e7IBDcbM1waLPXfuS1ShnE6JDay8mum8EVX91uTwJhml6IKcCH0KbIAG59RN4JOO3DG5MPVjcYVcQeA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.6",
-        "postcss-advanced-variables": "^3.0.0",
+        "postcss": "^8.3.11",
+        "postcss-advanced-variables": "^3.0.1",
         "postcss-atroot": "^0.1.3",
         "postcss-extend-rule": "^2.0.0",
-        "postcss-nested": "^4.1.0",
-        "postcss-preset-env": "^6.4.0",
+        "postcss-nested": "^4.2.3",
+        "postcss-preset-env": "^6.7.0",
         "postcss-property-lookup": "^2.0.0"
       },
       "dependencies": {
@@ -22582,26 +23056,16 @@
             "picocolors": "^0.2.1",
             "postcss": "^7.0.32",
             "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
           },
           "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
               }
             }
           }
@@ -22613,6 +23077,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.5"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "css-has-pseudo": {
@@ -22625,6 +23101,16 @@
             "postcss-selector-parser": "^5.0.0-rc.4"
           },
           "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            },
             "postcss-selector-parser": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
@@ -22645,6 +23131,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.5"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "cssdb": {
@@ -22665,17 +23163,6 @@
           "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
           "dev": true
         },
-        "postcss": {
-          "version": "7.0.36",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
         "postcss-attribute-case-insensitive": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz",
@@ -22684,6 +23171,18 @@
           "requires": {
             "postcss": "^7.0.2",
             "postcss-selector-parser": "^6.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-color-functional-notation": {
@@ -22694,6 +23193,18 @@
           "requires": {
             "postcss": "^7.0.2",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-color-hex-alpha": {
@@ -22704,6 +23215,18 @@
           "requires": {
             "postcss": "^7.0.14",
             "postcss-values-parser": "^2.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-color-rebeccapurple": {
@@ -22714,6 +23237,18 @@
           "requires": {
             "postcss": "^7.0.2",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-custom-media": {
@@ -22723,6 +23258,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.14"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-custom-properties": {
@@ -22733,6 +23280,18 @@
           "requires": {
             "postcss": "^7.0.17",
             "postcss-values-parser": "^2.0.1"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-custom-selectors": {
@@ -22745,6 +23304,16 @@
             "postcss-selector-parser": "^5.0.0-rc.3"
           },
           "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            },
             "postcss-selector-parser": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
@@ -22768,6 +23337,16 @@
             "postcss-selector-parser": "^5.0.0-rc.3"
           },
           "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            },
             "postcss-selector-parser": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
@@ -22789,6 +23368,18 @@
           "requires": {
             "postcss": "^7.0.5",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-env-function": {
@@ -22799,6 +23390,18 @@
           "requires": {
             "postcss": "^7.0.2",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-focus-visible": {
@@ -22808,6 +23411,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-focus-within": {
@@ -22817,6 +23432,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-font-variant": {
@@ -22826,6 +23453,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-gap-properties": {
@@ -22835,6 +23474,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-image-set-function": {
@@ -22845,6 +23496,18 @@
           "requires": {
             "postcss": "^7.0.2",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-initial": {
@@ -22854,6 +23517,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-lab-function": {
@@ -22865,6 +23540,18 @@
             "@csstools/convert-colors": "^1.4.0",
             "postcss": "^7.0.2",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-logical": {
@@ -22874,6 +23561,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-media-minmax": {
@@ -22883,6 +23582,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-nesting": {
@@ -22892,6 +23603,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-overflow-shorthand": {
@@ -22901,6 +23624,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-page-break": {
@@ -22910,6 +23645,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-place": {
@@ -22920,6 +23667,18 @@
           "requires": {
             "postcss": "^7.0.2",
             "postcss-values-parser": "^2.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-preset-env": {
@@ -22965,6 +23724,18 @@
             "postcss-replace-overflow-wrap": "^3.0.0",
             "postcss-selector-matches": "^4.0.0",
             "postcss-selector-not": "^4.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-pseudo-class-any-link": {
@@ -22977,6 +23748,16 @@
             "postcss-selector-parser": "^5.0.0-rc.3"
           },
           "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            },
             "postcss-selector-parser": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
@@ -22997,6 +23778,18 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.2"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         },
         "postcss-selector-not": {
@@ -23007,15 +23800,18 @@
           "requires": {
             "balanced-match": "^1.0.0",
             "postcss": "^7.0.2"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "7.0.39",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+              "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+              "dev": true,
+              "requires": {
+                "picocolors": "^0.2.1",
+                "source-map": "^0.6.1"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "postcss-import": "^14.1.0",
     "postcss-loader": "^7.0.0",
     "postcss-preset-env": "^7.6.0",
-    "precss": "^4.0.0",
+    "precss-v8": "^5.0.1",
     "standard": "^17.0.0",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,6 +2,6 @@ module.exports = {
   plugins: [
     require('postcss-preset-env'),
     require('postcss-import'),
-    require('precss')
+    require('precss-v8')
   ]
 }


### PR DESCRIPTION
`precss` says “Package no longer supported”.
(https://www.npmjs.com/package/precss)

Replace with precss-v8 to resolve security alerts.